### PR TITLE
Initial commit migrating this to AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.terraform/

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.64.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:xstX5ub6MZ+PSrrZbB0ElhThX8N2ShQThR3m8nMZ928=",
+    "zh:092614f767995140cf444cad1a97fb569885db16cb1c1dc9ee56e801232bac29",
+    "zh:142e262fbb162c8a86493cfab4aadaf96a8572f1a3a6be444d465a4aee377dba",
+    "zh:1c58c8cb9934dc98a2dd9dc48a8a3d94a14c2c3f2bc0136410a9344938d4ecfb",
+    "zh:36efdf30cd52b92668cf6f912538c6e176b1a140a00e63ee0f753b85878c8b53",
+    "zh:4c631e367fd69692b57f85564de561733380e9674e146d3a7725b781ec5db944",
+    "zh:57ace91cb022ec944ad3af9272b78f48e7f71e9d1bf113ca56c6ce8deb4341fe",
+    "zh:7fc9581b530ebf28fda80c62c20c6fbbb936a878c24872349eb107b7f198e64c",
+    "zh:8280cd8f04c31af83f3e74f07704b258fbaa8bf1d70679d5ea2f0cbda2571de2",
+    "zh:8e6217a9443b651d4349d75bdc37af9298970d854bf515d8c305919b193e4a38",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c62bc4a9034a6caf15b8863da6f5a621b947d5fca161b4bd2f2e8e78eec8e3b",
+    "zh:9d0a45cd4a031d19ee14c0a15f25df6359dcd342ccf4e2ee4751b3ee496edb57",
+    "zh:ab47f4e300c46dc1757e2b8d8d749f34f044f219479106a00bf40572091a8999",
+    "zh:b55119290497dda96ab9ba3dca00d648808dc99d18960ad8aa875775bfaf95db",
+    "zh:df513941e6979f557edcac28d84bd91af9786104b0deba45b3b259a5ad215897",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,42 @@
+
+// our controller can only run on ECS
+data "aws_iam_policy_document" "controller_assume_role_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "controller" {
+  statement {
+    sid    = "Controller IAM Policy"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "controller" {
+  name   = "controller"
+  path   = "/jenkins/"
+  policy = data.aws_iam_policy_document.controller.json
+}
+
+resource "aws_iam_role" "controller" {
+  name               = "controller"
+  path               = "/jenkins/"
+  assume_role_policy = data.aws_iam_policy_document.controller_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "controller" {
+  role       = aws_iam_role.controller.name
+  policy_arn = aws_iam_role.controller.arn
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  cloud {
+    organization = "bradschwartz"
+    workspaces {
+      name = "jenkinsci"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}


### PR DESCRIPTION
TF Cloud handles everything, and is configured as an oidc provider for credentials. The plan itself passing is more the point here, that the oidc stuff is setup correctly.